### PR TITLE
SQL Layout changes

### DIFF
--- a/babel.py
+++ b/babel.py
@@ -81,6 +81,7 @@ class Babel:
 
     def search_hex(self, hex=None, wall=None, shelf=None, volume=None):
         # Search a specific location for both titles and words
+        storage.create_sql_tables()
         if not hex:
             hex = generators.generate_animal_hex()
         self.hex = hex
@@ -126,12 +127,10 @@ class Babel:
             page_info = self.search_page_for_words(page_number, page_text, split_type="space")
 
             if page_info["Largest words"]:
-                if page_info["Consecutive count"] > 2 or len(page_info["Largest words"][0]) > 3:
-                    page_id = storage.handle_sql_page(self.title_id, page_number)
-                    if page_id and page_info["Consecutive count"] > 2:
-                        storage.handle_sql_consecutive_words(page_id, page_info)
-                    if page_id and len(page_info["Largest words"][0]) > 3:
-                        storage.sql_largest_word_on_page(page_id, page_info["Largest words"])
+                if page_info["Consecutive count"] > 1:
+                    storage.handle_sql_consecutive_words(self.title_id, page_info)
+                if len(page_info["Largest words"][0]) > 2:
+                    storage.sql_largest_word_on_page(self.title_id, page_number, page_info["Largest words"])
 
                 if book_largest_word["words"]:
                     if len(page_info["Largest words"][0]) > len(book_largest_word["words"][0]):
@@ -139,6 +138,7 @@ class Babel:
                 else:
                     book_largest_word.update({"page": page_number, "words": page_info["Largest words"]})
 
+        storage.sql_call_commit()
         return book_largest_word
 
     def search_page_for_words(self, page_number, page_text, split_type="space"):

--- a/babel.py
+++ b/babel.py
@@ -72,13 +72,13 @@ class Babel:
             consecutive_words, largest_words = self.find_words()
             stats = self.get_max_consecutive_words_for_book(consecutive_words)
             print("Book Location: " + self.get_book_location(),
-                  "\nBook Title: " + '\x1B[3m' + str(self.title) + '\x1B[0m'
-                  "\nMax word sets on a single page: " + str(stats.max_word_sets)
-                  + " (pg. " + str(stats.max_word_sets_page_num) + ")",
-                  "| Maximum consecutive words on a page: " + str(stats.max_consecutive_words)
-                  + " (pg." + str(stats.max_consecutive_words_page_num) + ")",
-                  "| Longest consecutive word group: " + str(stats.word_list)
-                  + " (pg." + str(stats.word_list_page_num) + ")")
+                  "\nBook Title: " + '\x1B[3m' + str(self.title) + '\x1B[0m',
+                  "\nMax word sets on a single page: "
+                  + str(stats.max_word_sets) + " (pg. " + str(stats.max_word_sets_page_num) + ")",
+                  "| Maximum consecutive words on a page: "
+                  + str(stats.max_consecutive_words) + " (pg." + str(stats.max_consecutive_words_page_num) + ")",
+                  "| Longest consecutive word group: "
+                  + str(stats.word_list) + " (pg." + str(stats.word_list_page_num) + ")")
             print("Largest words:")
             if len(largest_words) > 1:
                 for word in largest_words:

--- a/bookstats.py
+++ b/bookstats.py
@@ -1,0 +1,8 @@
+class BookStats():
+    def __init__(self):
+        self.max_consecutive_words: int = 0
+        self.max_consecutive_words_page_num: int = 0
+        self.max_word_sets: int = 0
+        self.max_word_sets_page_num: int = 0
+        self.word_list: list = []
+        self.word_list_page_num: int = 0

--- a/storage.py
+++ b/storage.py
@@ -5,8 +5,16 @@ db.row_factory = sqlite3.Row
 cur = db.cursor()
 
 
-def handle_sql_hex(hex):
+def create_sql_tables():
     cur.execute("CREATE TABLE IF NOT EXISTS hexes(hex_name)")
+    cur.execute("CREATE TABLE IF NOT EXISTS titles(rowid INTEGER PRIMARY KEY, title, hex, wall, shelf, volume)")
+    cur.execute("""CREATE TABLE IF NOT EXISTS consecutive_words(rowid INTEGER PRIMARY KEY, title_id, page_num,
+                    num_consecutive_words, num_word_sets, words)""")
+    cur.execute("CREATE TABLE IF NOT EXISTS page_words(rowid INTEGER PRIMARY KEY, title_id, page_num, length, word)")
+    cur.execute("CREATE TABLE IF NOT EXISTS significant_titles(rowid INTEGER PRIMARY KEY, words, title)")
+    db.commit()
+
+def handle_sql_hex(hex):
     result = cur.execute("SELECT ROWID FROM hexes WHERE hex_name = ?", (hex, ))
     hex_row_id = result.fetchall()
     if len(hex_row_id) == 0:
@@ -23,7 +31,6 @@ def handle_sql_hex(hex):
 
 
 def handle_sql_title(title, hex_id, hex, wall, shelf, volume):
-    cur.execute("CREATE TABLE IF NOT EXISTS titles(rowid INTEGER PRIMARY KEY, title, hex, wall, shelf, volume)")
     result = cur.execute("SELECT * FROM titles WHERE title = ? AND hex = ? AND wall = ? AND shelf = ? AND volume = ?",
                    (title, hex_id, int(wall), int(shelf), int(volume)))
     titles = result.fetchall()
@@ -40,53 +47,35 @@ def handle_sql_title(title, hex_id, hex, wall, shelf, volume):
     else:
         raise Exception("Title exists in hexes table more than once!")
 
-
-def handle_sql_page(title_id, page_number):
-    cur.execute("""CREATE TABLE IF NOT EXISTS pages(rowid INTEGER PRIMARY KEY, title_id, page_number)""")
-    result = cur.execute("SELECT * FROM pages WHERE title_id = ? and page_number = ?",
-                         (title_id, page_number))
+def handle_sql_consecutive_words(title_id, page_info):
+    result = cur.execute("SELECT * FROM consecutive_words WHERE title_id = ? and page_num = ?",
+                         (title_id, int(page_info["Page number"])))
     page = result.fetchall()
     if len(page) == 0:
-        cur.execute("INSERT INTO pages (title_id, page_number) values (?, ?)", (title_id, page_number))
-        db.commit()
-        return cur.lastrowid
-    elif len(page) == 1:
-        return page[0]["rowid"]
-    else:
-        raise Exception("Page exists in pages table more than once!")
-
-
-def handle_sql_consecutive_words(page_id, page_info):
-    cur.execute("""CREATE TABLE IF NOT EXISTS consecutive_words(rowid INTEGER PRIMARY KEY, page_id,
-                num_consecutive_words, num_word_sets, words)""")
-    result = cur.execute("SELECT * FROM consecutive_words WHERE page_id = ?", (page_id, ))
-    page = result.fetchall()
-    if len(page) == 0:
-        cur.execute("""INSERT INTO consecutive_words (page_id, num_consecutive_words, num_word_sets,
-                        words) values (?, ?, ?, ?)""",
-                    (page_id,
+        cur.execute("""INSERT INTO consecutive_words (title_id, page_num, num_consecutive_words, num_word_sets,
+                        words) values (?, ?, ?, ?, ?)""",
+                    (title_id,
+                     int(page_info["Page number"]),
                      int(page_info["Consecutive count"]),
                      len(page_info["Consecutive word sets"]),
                      str(page_info["Consecutive word sets"]))
                     )
-        db.commit()
-        return True
-    else:
-        return False
 
-def sql_largest_word_on_page(page_id, largest_words):
-    cur.execute("CREATE TABLE IF NOT EXISTS page_words(rowid INTEGER PRIMARY KEY, page_id, length, word)")
-    result = cur.execute("SELECT * FROM page_words WHERE page_id = ?", (page_id, ))
+def sql_largest_word_on_page(title_id, page_num, largest_words):
+    result = cur.execute("SELECT * FROM page_words WHERE title_id = ? and page_num = ?",
+                         (title_id, page_num))
     page = result.fetchall()
     if len(page) == 0:
         if len(largest_words) > 0:
             for word in largest_words:
-                cur.execute("INSERT INTO page_words (page_id, length, word) values (?, ?, ?)",
-                            (page_id, len(word), word))
-                db.commit()
+                cur.execute("INSERT INTO page_words (title_id, page_num, length, word) values (?, ?, ?, ?)",
+                            (title_id, page_num, len(word), word))
+
+
+def sql_call_commit():
+    db.commit()
 
 def significant_title_entry(word_string, title_id):
-    cur.execute("CREATE TABLE IF NOT EXISTS significant_titles(rowid INTEGER PRIMARY KEY, words, title)")
     cur.execute("INSERT INTO significant_titles SET words = ?, title = ?",
                 (word_string, title_id))
     db.commit()


### PR DESCRIPTION
The longest words on each page is now stored in the DB in a separate table (page_words)
The longest grouping of words on each page is now stored in it's own table (consecutive_words)
Updated the final display of both those stats when outputting results to console
Moved table create calls into their own function that should be run at start