### PR TITLE
Dash website output

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ a book using an API call to directly download it, then using an english language
 through each book and provide output via the console window and into a SQLite database. It primarily searches 
 for words that are next to each other, while also keeping track of the largest word it found.
 
-## Developer notes:
+## Developer notes
 I've been casually working on this for many years as a way to improve my own coding skills, to fill my fanciful need for
 discovery, and to otherwise amuse myself by coding. I never intended the code to be public, but since others have shown
 interest in using such a program, I have decided to make steps to get it out in the open. 
@@ -31,7 +31,7 @@ to make it more user-friendly in general.
 0. ~~Code cleanup and refactoring~~
 1. ~~Allow for easy running of scripts for non-technical users. This will likely include a way to store results that does 
 not require MySQL.~~
-2. Better reporting in general, ideally with some fancy local website creation, or something to that effect.
+2. ~~Better reporting in general, ideally with some fancy local website creation, or something to that effect.~~
 3. More search options
 
 
@@ -49,6 +49,14 @@ stay only with this venv) and activate it
 babel.db located in the root directory of the program, this db can be accessed with any Sqllite workbench, such as
 SQLitestudio: https://sqlitestudio.pl/
 
+# Other options
+Specific location start can with the flags --wall, --shelf and --volume or -w, -s and -v. For example to start at 
+wall 3, shelf 2 and volume 4 of hex 'specifiedhex' by typing `python runbabel.py specifiedhex -f -w 3 -s 2 -v 4`
+
+You can view a generated website with your findings by `python runbabel.py --results`, which will create a local
+website viewable at `http://127.0.0.1:8050/`  An example of this output is shown below.
+
+<img src="https://i.imgur.com/F1gyA4B.png" width="50%" height="50%">
 
 
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ wall 3, shelf 2 and volume 4 of hex 'specifiedhex' by typing `python runbabel.py
 You can view a generated website with your findings by `python runbabel.py --results`, which will create a local
 website viewable at `http://127.0.0.1:8050/`  An example of this output is shown below.
 
-<img src="https://i.imgur.com/F1gyA4B.png" width="50%" height="50%">
+<img src="https://i.imgur.com/qqjtBbs.png" width="50%" height="50%">
 
 
 

--- a/reporting/dash_output.py
+++ b/reporting/dash_output.py
@@ -2,7 +2,7 @@ from dash import Dash, html, dash_table, dcc
 import pandas as pd
 import plotly.express as px
 import sqlite3
-
+import logging
 
 def run_sql_with_query():
     conn = sqlite3.connect('babel.db')
@@ -156,7 +156,8 @@ def run_sql_with_query():
     style = {'marginBottom': 50, 'marginTop': 25},
     )
 
-    app.run(debug=True)
+    logging.getLogger('werkzeug').setLevel(logging.ERROR)
+    app.run(debug=False)
 
 def words_table(data_variable):
     return dash_table.DataTable(data=data_variable.to_dict('records'), sort_action="native",

--- a/reporting/dash_output.py
+++ b/reporting/dash_output.py
@@ -43,7 +43,8 @@ def run_sql_with_query():
                             from page_words as p
                             join titles as t on p.title_id=t.rowid
                             join hexes as h on t.hex=h.rowid
-                            where p.length = ?"""}
+                            where p.length = ?
+                            order by p.rowid desc"""}
 
     totals = pd.read_sql_query(sql["totals"], conn).to_dict('records')[0]
     total_words = pd.read_sql_query(sql["total_words"], conn).to_dict('records')

--- a/reporting/dash_output.py
+++ b/reporting/dash_output.py
@@ -33,10 +33,12 @@ def run_sql_with_query():
                "most_consec_words": """select num_consecutive_words as amount from consecutive_words as c
                         where amount = (SELECT max(num_consecutive_words) from consecutive_words)
                         group by amount;""",
-               "hex_completion": """select count(*) as Books_Searched, h.hex_name from hexes as h
+               "hex_completion": """select (count(*) / 640.0) * 100.0 as Percent_Complete, h.hex_name as Hex_Name from hexes as h
                         join titles as t on h.rowid = t.hex
                         group by t.hex
-                        order by Books_Searched desc;""",
+                        having count(*) < 640
+                        order by Percent_Complete desc
+                        limit 15;""",
                "words_markup": """ select "[" || p.word || "](" || "https://libraryofbabel.info/book.cgi?" || h.hex_name 
                             || "-w" || t.wall || "-s" || t.shelf || "-v" || printf('%02d', t.volume) || ":" 
                             || p.page_num || ")" as word_markup, t.title, h.hex_name, p.page_num
@@ -145,7 +147,11 @@ def run_sql_with_query():
             words_table(largest_words2),
             html.H2(children=str(longest_word["length"] - 2) + " characters"),
             words_table(largest_words3),
-            dcc.Graph(figure=px.bar(hex_completion, x='hex_name', y='Books_Searched'))
+            dcc.Graph(figure=px.bar(hex_completion, title='Un-completed hexes', x='Hex_Name', y='Percent_Complete'),
+                      style={
+                          'width': 1400,
+                          'height': 600
+                      })
         ],
     style = {'marginBottom': 50, 'marginTop': 25},
     )

--- a/reporting/dash_output.py
+++ b/reporting/dash_output.py
@@ -1,0 +1,173 @@
+from dash import Dash, html, dash_table, dcc
+import pandas as pd
+import plotly.express as px
+import sqlite3
+
+
+def run_sql_with_query():
+    conn = sqlite3.connect('babel.db')
+    sql = {"large_words": """select p.word, t.title, h.hex_name, p.page_num,
+                        "https://libraryofbabel.info/book.cgi?" || h.hex_name || "-w" || t.wall || "-s" || t.shelf || "-v" 
+                        || printf('%02d', t.volume) || ":" || p.page_num as URL from page_words as p
+                        join titles as t on p.title_id=t.rowid
+                        join hexes as h on t.hex=h.rowid
+                        where p.length = (SELECT max(length) FROM page_words)""",
+               "totals": """select count(title) as Total_Books, count(title) * 410 as Total_Pages from titles""",
+               "full_hex": """select count(*) as Full_Hexes
+                        from (select count(*) from hexes as h
+                        join titles as t on h.rowid = t.hex
+                        group by t.hex
+                        having count(*) >= 640)""",
+               "full_wall": """select count(*) as Full_Walls
+                        from (select count(*) from titles
+                        group by hex, wall
+                        having count(*) >= 160)""",
+               "full_shelf": """select count(*) as Full_Shelves
+                        from (select count(*) from titles
+                        group by hex, wall, shelf
+                        having count(*) >= 32)""",
+               "total_words": """select count(*) as num_words from page_words where length >= 3""",
+               "longest_word": """select length from page_words
+                        where length = (SELECT max(length) FROM page_words)
+                        group by length""",
+               "most_consec_words": """select num_consecutive_words as amount from consecutive_words as c
+                        where amount = (SELECT max(num_consecutive_words) from consecutive_words)
+                        group by amount;""",
+               "hex_completion": """select count(*) as Books_Searched, h.hex_name from hexes as h
+                        join titles as t on h.rowid = t.hex
+                        group by t.hex
+                        order by Books_Searched desc;""",
+               "words_markup": """ select "[" || p.word || "](" || "https://libraryofbabel.info/book.cgi?" || h.hex_name 
+                            || "-w" || t.wall || "-s" || t.shelf || "-v" || printf('%02d', t.volume) || ":" 
+                            || p.page_num || ")" as word_markup, t.title, h.hex_name, p.page_num
+                            from page_words as p
+                            join titles as t on p.title_id=t.rowid
+                            join hexes as h on t.hex=h.rowid
+                            where p.length = ?"""}
+
+    totals = pd.read_sql_query(sql["totals"], conn).to_dict('records')[0]
+    total_words = pd.read_sql_query(sql["total_words"], conn).to_dict('records')
+    total_words = f"{total_words[0]["num_words"]:,}"
+    longest_word = pd.read_sql_query(sql["longest_word"], conn).to_dict('records')[0]
+    full_hex = pd.read_sql_query(sql["full_hex"], conn).to_dict('records')[0]
+    full_walls = pd.read_sql_query(sql["full_wall"], conn).to_dict('records')[0]
+    full_shelves = pd.read_sql_query(sql["full_shelf"], conn).to_dict('records')[0]
+    most_consec_words = pd.read_sql_query(sql["most_consec_words"], conn).to_dict('records')[0]
+    largest_words = pd.read_sql_query(sql=sql["words_markup"], con=conn, params=[longest_word["length"]])
+    largest_words2 = pd.read_sql_query(sql=sql["words_markup"], con=conn, params=[longest_word["length"]-1])
+    largest_words3 = pd.read_sql_query(sql=sql["words_markup"], con=conn, params=[longest_word["length"] - 2])
+    hex_completion = pd.read_sql_query(sql["hex_completion"], conn)
+
+    app = Dash()
+
+    app.layout = html.Div(
+        [
+        html.H1(children="Your Babel Search Stats"),
+        html.Tbody([
+            html.Tr([
+                html.Td([
+                    html.H3(children="Total books searched:")
+                ]),
+                html.Td([
+                    html.Div(children=f"{totals["Total_Books"]:,}", style={'text-align': 'right'})
+                ]),
+                html.Td([
+
+                ], style={'width': 50}),
+                html.Td([
+                    html.H3(children="Words found > 3 characters: ")
+                ], style={'width': 250}),
+                html.Td([
+                    html.Div(children=total_words, style={'text-align': 'right'})
+                ]),
+            ]),
+            html.Tr([
+                html.Td([
+                    html.H3(children="Total pages searched:")
+                ]),
+                html.Td([
+                    html.Div(children=f"{totals["Total_Pages"]:,}", style={'text-align': 'right'})
+                ]),
+                html.Td([
+
+                ]),
+                html.Td([
+                    html.H3(children="Longest word length: ")
+                ]),
+                html.Td([
+                    html.Div(children=longest_word["length"], style={'text-align': 'right'})
+                ]),
+            ]),
+            html.Tr([
+                html.Td([
+                    html.H3(children="Full Hexes Searched:")
+                ]),
+                html.Td([
+                    html.Div(children=f"{full_hex["Full_Hexes"]:,}", style={'text-align': 'right'})
+                ]),
+                html.Td([
+
+                ]),
+                html.Td([
+                    html.H3(children="Most consecutive words: ")
+                ]),
+                html.Td([
+                    html.Div(children=most_consec_words["amount"], style={'text-align': 'right'})
+                ]),
+            ]),
+            html.Tr([
+                html.Td([
+                    html.H3(children="Full Walls Searched:")
+                ]),
+                html.Td([
+                    html.Div(children=f"{full_walls["Full_Walls"]:,}", style={'text-align': 'right'})
+                ]),
+                html.Td([]),
+                html.Td([]),
+                html.Td([]),
+            ]),
+            html.Tr([
+                html.Td([
+                    html.H3(children="Full Shelves Searched:")
+                ]),
+                html.Td([
+                    html.Div(children=f"{full_shelves["Full_Shelves"]:,}", style={'text-align': 'right'})
+                ]),
+                html.Td([]),
+                html.Td([]),
+                html.Td([]),
+            ]),
+        ]),
+            html.H2(children=str(longest_word["length"]) + " characters"),
+            words_table(largest_words),
+            html.H2(children=str(longest_word["length"] - 1) + " characters"),
+            words_table(largest_words2),
+            html.H2(children=str(longest_word["length"] - 2) + " characters"),
+            words_table(largest_words3),
+            dcc.Graph(figure=px.bar(hex_completion, x='hex_name', y='Books_Searched'))
+        ],
+    style = {'marginBottom': 50, 'marginTop': 25},
+    )
+
+    app.run(debug=True)
+
+def words_table(data_variable):
+    return dash_table.DataTable(data=data_variable.to_dict('records'), sort_action="native",
+                         columns=[{'name': 'Word', 'id': 'word_markup', 'type': 'text', 'presentation': 'markdown'},
+                                  {'name': 'Title', 'id': 'title'}],
+                         style_table={
+                             'width': 700,
+                         },
+                         style_header={
+                             "color": "white",
+                             "backgroundColor": "#799DBF",
+                             "fontWeight": "bold",
+                             "textAlign": "center",
+                         },
+                         style_data={
+                             'minWidth': '75px', 'maxWidth': '600px',
+                             'overflow': 'hidden',
+                             'textOverflow': 'ellipsis',
+                             'textAlign': 'left',
+                         },
+                         page_size=10)

--- a/runbabel.py
+++ b/runbabel.py
@@ -1,10 +1,14 @@
 import argparse
 import babel
+import reporting.dash_output as output
 
 parser = argparse.ArgumentParser()
 parser.add_argument('hex', type=str,  nargs='*', default=None, help='hex name to search, will generate a random string if none is given')
 parser.add_argument('-f', '--full', help='search full books for strings of text', action='store_true')
-
+parser.add_argument('-w', '--wall', type=int)
+parser.add_argument('-s', '--shelf', type=int)
+parser.add_argument('-v', '--volume', type=int)
+parser.add_argument('-r', '--results', help='Display results webpage', action='store_true')
 args = parser.parse_args()
 
 if args.full:
@@ -12,9 +16,15 @@ if args.full:
     if args.hex:
         if args.hex[0].isalnum():  # make sure hex name is only alphanumeric
             hex_name = args.hex[0].lower()
-            b.search_hex(hex=hex_name)
+            if args.wall and args.shelf and args.volume:
+                b.search_hex(hex=hex_name, wall=args.wall, shelf=args.shelf, volume=args.volume)
+            else:
+                b.search_hex(hex=hex_name)
         else:
             print("Hex name can only include numbers and letters with no special characters or spaces")
             exit()
     else:
         b.search_hex()
+
+elif args.results:
+    output.run_sql_with_query()

--- a/storage.py
+++ b/storage.py
@@ -6,7 +6,7 @@ cur = db.cursor()
 
 
 def create_sql_tables():
-    cur.execute("CREATE TABLE IF NOT EXISTS hexes(hex_name)")
+    cur.execute("CREATE TABLE IF NOT EXISTS hexes(rowid INTEGER PRIMARY KEY, hex_name)")
     cur.execute("CREATE TABLE IF NOT EXISTS titles(rowid INTEGER PRIMARY KEY, title, hex, wall, shelf, volume)")
     cur.execute("""CREATE TABLE IF NOT EXISTS consecutive_words(rowid INTEGER PRIMARY KEY, title_id, page_num,
                     num_consecutive_words, num_word_sets, words)""")


### PR DESCRIPTION
Added an easy way to see search stats. Simply use the `-r` parameter and the program will spin up a website that runs on your local machine with all the important stats of your search history.